### PR TITLE
read from stdin when `-state` not provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.0.3
+VERSION = 0.0.4
 SOURCE = ./...
 
 .PHONY: help \

--- a/README.md
+++ b/README.md
@@ -6,18 +6,29 @@ A CLI to generate Terraform outputs documentation.
 
 ## What's the use case?
 
-Invoke `terraputs -state $(terraform show -json) > outputs.md` after each invocation of `terraform apply`. Commit `outputs.md` to source control or publish its contents to offer up-to-date Terraform state documentation.
+`terraputs` analyzes the contents of a [terraform state](https://www.terraform.io/docs/language/state/index.html)
+file and generates Markdown documentation from its [outputs](https://www.terraform.io/docs/language/values/outputs.html).
+
+A common workflow might execute `terraputs -state $(terraform show -json) > outputs.md` after each
+invocation of `terraform apply`, then commit `outputs.md` to source control or publish its contents to
+offer up-to-date documentation about resources managed by a Terraform project.
 
 <a style="display: block;" href="https://asciinema.org/a/lFUVfdhes0i1cVbtFUvzwLMKd"><img style="width: 500px;" src="demo.svg"></a>
 
 ## Usage
 
-Basic usage:
+A few typical usage examples:
 
 ```
-terraputs \
-  -state $(terraform show -json) \
-  -heading "Terraform Outputs"
+# terraputs can accept arbitrary state as a string argument on the command line:
+terraputs -state "$(terraform show -json)" -heading "Terraform Outputs"
+
+# or directly from standard input, if the -state option is omitted. to read
+# directly from terraform, consider:
+terraform show -json | terraputs -heading "Terraform Outputs"
+
+# or read a tfstate file from the filesystem:
+terraputs < terraform.tfstate
 ```
 
 Example output:
@@ -44,7 +55,7 @@ Usage of terraputs:
   -heading string
         Optional; the heading text for use in the printed markdown (default "Outputs")
   -state string
-        Required; the state JSON output by 'terraform show -json'
+        Optional; the state JSON output by 'terraform show -json', read from stdin if omitted
 ```
 
 ## Example output table formatted by GitHub

--- a/main.go
+++ b/main.go
@@ -58,10 +58,8 @@ func main() {
 		return
 	}
 
-	var stateReader io.Reader
-	if *stateJSON == "" {
-		stateReader = bufio.NewReader(os.Stdin)
-	} else {
+	var stateReader io.Reader = bufio.NewReader(os.Stdin)
+	if *stateJSON != "" {
 		stateReader = strings.NewReader(*stateJSON)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"embed"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"html/template"
+	"io"
 	"os"
 	"strings"
 
@@ -23,7 +24,7 @@ var (
 )
 
 const (
-	stateDesc      string = "Required; the state JSON output by 'terraform show -json'"
+	stateDesc      string = "Optional; the state JSON output by 'terraform show -json', read from stdin if omitted"
 	headingDesc    string = "Optional; the heading text for use in the printed markdown"
 	versionDesc    string = "Print the current version and exit"
 	defaultHeading string = "Outputs"
@@ -57,12 +58,15 @@ func main() {
 		return
 	}
 
+	var stateReader io.Reader
 	if *stateJSON == "" {
-		panic(errors.New("Mising required '-state' value"))
+		stateReader = bufio.NewReader(os.Stdin)
+	} else {
+		stateReader = strings.NewReader(*stateJSON)
 	}
 
 	var state *tfjson.State
-	if err := json.NewDecoder(strings.NewReader(*stateJSON)).Decode(&state); err != nil {
+	if err := json.NewDecoder(stateReader).Decode(&state); err != nil {
 		panic(err)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -87,13 +87,8 @@ func TestVersionArg(t *testing.T) {
 	}
 }
 
-// test cases:
-//
-// -state and -statefile together should error
-//
 // these should all be ok and functionally equivalent:
 //   terraputs -state "$(cat stateFile)"
-//   terraputs -statefile stateFile
 //   terraputs < stateFile
 //   cat stateFile | terraputs
 


### PR DESCRIPTION
quick implementation of #6 - read state from stdin if `-state <...>` is omitted. i opted to keep the existing CLI interface intact for now, in order to maintain backward compatibility with the existing release version. test cases aren't very DRY atm (as the tables are inline and several expect the same output) but they do now exist for the stdin case. i'd also like to add a `-statefile <...>` option at some point to let terraputs handle the statefile IO for cases where pipes or file redirection aren't well supported.

what's enclosed in the swag implementation will let us get away with these additional use cases:

```
$ terraform show -json | terraputs
$ terraputs < terraform.tfstate
```