### PR TITLE
support a '-state-file' option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.0.5
+VERSION = 0.1.0
 SOURCE = ./...
 
 .PHONY: help \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Usage of terraputs:
         Optional; the heading text for use in the printed markdown (default "Outputs")
   -state string
         Optional; the state JSON output by 'terraform show -json', read from stdin if omitted
+  -state-file string
+        Optional; the path to a local file containing 'terraform show -json' output
 ```
 
 ## Example output table formatted by GitHub

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 
 const (
 	stateDesc      string = "Optional; the state JSON output by 'terraform show -json', read from stdin if omitted"
-	stateFileDesc  string = "Optional; the path to a local Terraform state JSON file"
+	stateFileDesc  string = "Optional; the path to a local file containing 'terraform show -json' output"
 	headingDesc    string = "Optional; the heading text for use in the printed markdown"
 	versionDesc    string = "Print the current version and exit"
 	defaultHeading string = "Outputs"


### PR DESCRIPTION
This adds support for a '-state-file' option whose value
is the path to a local state JSON file.

This is especially useful for systems and automation that
may choke on lengthy, verbose `$(terraform show -json)` output
resulting from big, complex Terraform configurations.