### PR TITLE
add support for '-output html' option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.1.0
+VERSION = 0.1.1
 SOURCE = ./...
 
 .PHONY: help \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A CLI to generate Terraform outputs documentation.
 ## What's the use case?
 
 `terraputs` analyzes the contents of a [terraform state](https://www.terraform.io/docs/language/state/index.html)
-file and generates Markdown documentation from its [outputs](https://www.terraform.io/docs/language/values/outputs.html).
+file and generates Markdown or HTML documentation from its [outputs](https://www.terraform.io/docs/language/values/outputs.html).
 
 A common workflow might execute `terraputs -state $(terraform show -json) > outputs.md` after each
 invocation of `terraform apply`, then commit `outputs.md` to source control or publish its contents to
@@ -31,7 +31,7 @@ terraform show -json | terraputs -heading "Terraform Outputs"
 terraputs < terraform.tfstate
 ```
 
-Example output:
+Example markdown output:
 
 ```
 # Terraform Outputs
@@ -53,14 +53,16 @@ Terraform state outputs.
 terraputs -h
 Usage of terraputs:
   -heading string
-        Optional; the heading text for use in the printed markdown (default "Outputs")
+        Optional; the heading text for use in the printed output. Default: Outputs (default "Outputs")
+  -output string
+        Optional; the output format. Supported values: md, html. Default: md (default "md")
   -state string
-        Optional; the state JSON output by 'terraform show -json', read from stdin if omitted
+        Optional; the state JSON output by 'terraform show -json'. Read from stdin if omitted
   -state-file string
         Optional; the path to a local file containing 'terraform show -json' output
 ```
 
-## Example output table formatted by GitHub
+## Example markdown output table formatted by GitHub
 
 | Output | Value | Type
 | --- | --- | --- |
@@ -74,6 +76,5 @@ Usage of terraputs:
 
 * provide the ability to pass a custom template
 * improve the formatting and readability of lists and maps
-* create automated releases
 * create a GitHub Action
 * publish an OCI image

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ terraform show -json | terraputs -heading "Terraform Outputs"
 terraputs < terraform.tfstate
 ```
 
+### Results examples
+
 <details>
 
 <summary>Example markdown output</summary>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ terraform show -json | terraputs -heading "Terraform Outputs"
 terraputs < terraform.tfstate
 ```
 
-Example markdown output:
+<details>
+
+<summary>Example markdown output</summary>
 
 ```
 # Terraform Outputs
@@ -47,6 +49,147 @@ Terraform state outputs.
 | a_string | foo | string
 ```
 
+</details>
+
+<details>
+
+<summary>Markdown output rendered via GitHub-flavored markdown</summary>
+
+# Terraform Outputs
+
+Terraform state outputs.
+
+| Output | Value | Type
+| --- | --- | --- |
+| a_basic_map | map[foo:bar number:42] | map[string]interface {}
+| a_list | [foo bar] | []interface {}
+| a_nested_map | map[baz:map[bar:baz id:123] foo:bar number:42] | map[string]interface {}
+| a_sensitive_value | sensitive; redacted | string
+| a_string | foo | string
+
+</details>
+
+<details>
+
+<summary>Example HTML output</summary>
+
+```html
+<h2>Outputs</h2>
+<p>Terraform state outputs.</p>
+<table>
+  <tr>
+    <th>Output</th>
+    <th>Value</th>
+    <th>Type</th>
+  </tr>
+
+  <tr>
+    <td>a_basic_map</td>
+    <td><pre>{
+  "foo": "bar",
+  "number": 42
+}</pre></td>
+    <td>map[string]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_list</td>
+    <td><pre>[
+  "foo",
+  "bar"
+]</pre></td>
+    <td>[]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_nested_map</td>
+    <td><pre>{
+  "baz": {
+    "bar": "baz",
+    "id": "123"
+  },
+  "foo": "bar",
+  "number": 42
+}</pre></td>
+    <td>map[string]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_sensitive_value</td>
+    <td><pre>sensitive; redacted</pre></td>
+    <td>string</td>
+  </tr>
+
+  <tr>
+    <td>a_string</td>
+    <td><pre>"foo"</pre></td>
+    <td>string</td>
+  </tr>
+
+</table>
+```
+
+</details>
+
+<details>
+<summary>HTML output rendered via GitHub-flavored markdown</summary>
+
+<h2>Outputs</h2>
+<p>Terraform state outputs.</p>
+<table>
+  <tr>
+    <th>Output</th>
+    <th>Value</th>
+    <th>Type</th>
+  </tr>
+
+  <tr>
+    <td>a_basic_map</td>
+    <td><pre>{
+  "foo": "bar",
+  "number": 42
+}</pre></td>
+    <td>map[string]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_list</td>
+    <td><pre>[
+  "foo",
+  "bar"
+]</pre></td>
+    <td>[]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_nested_map</td>
+    <td><pre>{
+  "baz": {
+    "bar": "baz",
+    "id": "123"
+  },
+  "foo": "bar",
+  "number": 42
+}</pre></td>
+    <td>map[string]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_sensitive_value</td>
+    <td><pre>sensitive; redacted</pre></td>
+    <td>string</td>
+  </tr>
+
+  <tr>
+    <td>a_string</td>
+    <td><pre>"foo"</pre></td>
+    <td>string</td>
+  </tr>
+
+</table>
+
+</details>
+
 ## More options
 
 ```
@@ -61,16 +204,6 @@ Usage of terraputs:
   -state-file string
         Optional; the path to a local file containing 'terraform show -json' output
 ```
-
-## Example markdown output table formatted by GitHub
-
-| Output | Value | Type
-| --- | --- | --- |
-| a_basic_map | map[foo:bar number:42] | map[string]interface {}
-| a_list | [foo bar] | []interface {}
-| a_nested_map | map[baz:map[bar:baz id:123] foo:bar number:42] | map[string]interface {}
-| a_sensitive_value | sensitive; redacted | string
-| a_string | foo | string
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ offer up-to-date documentation about resources managed by a Terraform project.
 
 ## Usage
 
+```
+terraputs -h
+Usage of terraputs:
+  -heading string
+        Optional; the heading text for use in the printed output. (default "Outputs")
+  -output string
+        Optional; the output format. Supported values: md, html. (default "md")
+  -state string
+        Optional; the state JSON output by 'terraform show -json'. Read from stdin if omitted
+  -state-file string
+        Optional; the path to a local file containing 'terraform show -json' output
+```
+
 A few typical usage examples:
 
 ```
@@ -191,18 +204,3 @@ Terraform state outputs.
 </table>
 
 </details>
-
-## More options
-
-```
-terraputs -h
-Usage of terraputs:
-  -heading string
-        Optional; the heading text for use in the printed output. Default: Outputs (default "Outputs")
-  -output string
-        Optional; the output format. Supported values: md, html. Default: md (default "md")
-  -state string
-        Optional; the state JSON output by 'terraform show -json'. Read from stdin if omitted
-  -state-file string
-        Optional; the path to a local file containing 'terraform show -json' output
-```

--- a/README.md
+++ b/README.md
@@ -206,10 +206,3 @@ Usage of terraputs:
   -state-file string
         Optional; the path to a local file containing 'terraform show -json' output
 ```
-
-## TODO
-
-* provide the ability to pass a custom template
-* improve the formatting and readability of lists and maps
-* create a GitHub Action
-* publish an OCI image

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func getTemplatePath(output string) (string, error) {
 	case "md":
 		return "templates/markdown.tmpl", nil
 	default:
-		return "", fmt.Errorf("%s is not a supported output format. Supported formats: md (default), html", output)
+		return "", fmt.Errorf("'%s' is not a supported output format. Supported formats: 'md' (default), 'html'", output)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -27,8 +27,8 @@ var (
 const (
 	stateDesc      string = "Optional; the state JSON output by 'terraform show -json'. Read from stdin if omitted"
 	stateFileDesc  string = "Optional; the path to a local file containing 'terraform show -json' output"
-	headingDesc    string = "Optional; the heading text for use in the printed output. Default: Outputs"
-	outputDesc     string = "Optional; the output format. Supported values: md, html. Default: md"
+	headingDesc    string = "Optional; the heading text for use in the printed output."
+	outputDesc     string = "Optional; the output format. Supported values: md, html."
 	versionDesc    string = "Print the current version and exit"
 	defaultHeading string = "Outputs"
 	defaultOutput  string = "md"

--- a/main.go
+++ b/main.go
@@ -53,7 +53,10 @@ func prettyPrintValue(output tfjson.StateOutput) template.HTML {
 		return template.HTML(sensitive)
 	}
 
-	pretty, _ := json.MarshalIndent(output.Value, "", "  ")
+	pretty, err := json.MarshalIndent(output.Value, "", "  ")
+	if err != nil {
+		exit(err)
+	}
 
 	return template.HTML(string(pretty))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -37,6 +37,8 @@ func TestHelpFlag(t *testing.T) {
 		stateFileDesc,
 		"-heading string",
 		headingDesc,
+		"-output string",
+		outputDesc,
 	}
 
 	tests := []struct {
@@ -195,6 +197,50 @@ Terraform state outputs.
 
 `,
 	}, {
+		command: `./terraputs -state-file testdata/basic/show.json -heading foo -output html`,
+		expectedOutput: `<h2>foo</h2>
+<p>Terraform state outputs.</p>
+<table>
+  <tr>
+    <th>Output</th>
+    <th>Value</th>
+    <th>Type</th>
+  </tr>
+
+  <tr>
+    <td>a_basic_map</td>
+    <td>map[foo:bar number:42]</td>
+    <td>map[string]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_list</td>
+    <td>[foo bar]</td>
+    <td>[]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_nested_map</td>
+    <td>map[baz:map[bar:baz id:123] foo:bar number:42]</td>
+    <td>map[string]interface {}</td>
+  </tr>
+
+  <tr>
+    <td>a_sensitive_value</td>
+    <td>sensitive; redacted</td>
+    <td>string</td>
+  </tr>
+
+  <tr>
+    <td>a_string</td>
+    <td>foo</td>
+    <td>string</td>
+  </tr>
+
+</table>
+`,
+	}, {
+
 		command: `./terraputs -state-file testdata/nooutputs/show.json -heading foo`,
 		expectedOutput: `# foo
 

--- a/main_test.go
+++ b/main_test.go
@@ -209,31 +209,44 @@ Terraform state outputs.
 
   <tr>
     <td>a_basic_map</td>
-    <td>map[foo:bar number:42]</td>
+    <td><pre>{
+  "foo": "bar",
+  "number": 42
+}</pre></td>
     <td>map[string]interface {}</td>
   </tr>
 
   <tr>
     <td>a_list</td>
-    <td>[foo bar]</td>
+    <td><pre>[
+  "foo",
+  "bar"
+]</pre></td>
     <td>[]interface {}</td>
   </tr>
 
   <tr>
     <td>a_nested_map</td>
-    <td>map[baz:map[bar:baz id:123] foo:bar number:42]</td>
+    <td><pre>{
+  "baz": {
+    "bar": "baz",
+    "id": "123"
+  },
+  "foo": "bar",
+  "number": 42
+}</pre></td>
     <td>map[string]interface {}</td>
   </tr>
 
   <tr>
     <td>a_sensitive_value</td>
-    <td>sensitive; redacted</td>
+    <td><pre>sensitive; redacted</pre></td>
     <td>string</td>
   </tr>
 
   <tr>
     <td>a_string</td>
-    <td>foo</td>
+    <td><pre>"foo"</pre></td>
     <td>string</td>
   </tr>
 

--- a/main_test.go
+++ b/main_test.go
@@ -281,6 +281,10 @@ Terraform state outputs.
 		command:        `./terraputs -state $(cat testdata/basic/show.json) -state-file testdata/basic/show.json -heading foo`,
 		expectedError:  errors.New("exit status 1"),
 		expectedOutput: "'-state' and '-state-file' are mutually exclusive; specify just one",
+	}, {
+		command:        `./terraputs -state $(cat testdata/basic/show.json) -output foo`,
+		expectedError:  errors.New("exit status 1"),
+		expectedOutput: "'foo' is not a supported output format. Supported formats: 'md' (default), 'html'",
 	}}
 
 	for _, test := range tests {

--- a/templates/html.tmpl
+++ b/templates/html.tmpl
@@ -6,11 +6,11 @@
     <th>Value</th>
     <th>Type</th>
   </tr>
-  {{ range $key, $value := .Outputs }}
+{{ range $key, $value := .Outputs }}
   <tr>
     <td>{{ $key }}</td>
     <td>{{ value $value }}</td>
     <td>{{ dataType $value }}</td>
   </tr>
-  {{ end }}
+{{ end }}
 </table>

--- a/templates/html.tmpl
+++ b/templates/html.tmpl
@@ -9,7 +9,7 @@
 {{ range $key, $value := .Outputs }}
   <tr>
     <td>{{ $key }}</td>
-    <td>{{ value $value }}</td>
+    <td><pre>{{ prettyPrint $value }}</pre></td>
     <td>{{ dataType $value }}</td>
   </tr>
 {{ end }}

--- a/templates/html.tmpl
+++ b/templates/html.tmpl
@@ -1,0 +1,16 @@
+<h2>{{ .Heading }}</h2>
+<p>Terraform state outputs.</p>
+<table>
+  <tr>
+    <th>Output</th>
+    <th>Value</th>
+    <th>Type</th>
+  </tr>
+  {{ range $key, $value := .Outputs }}
+  <tr>
+    <td>{{ $key }}</td>
+    <td>{{ value $value }}</td>
+    <td>{{ dataType $value }}</td>
+  </tr>
+  {{ end }}
+</table>


### PR DESCRIPTION
This seeks to address issue #10 (improve the output formatting) and issue #12 (support HTML output).

To view some examples of its output -- including rendering by GitHub-flavored markdown -- see the rendered `README.md`: https://github.com/mdb/terraputs/tree/html-output#results-examples